### PR TITLE
Refactor to use rb_check_id_cstr for id resolution

### DIFF
--- a/include/natalie_parser/creator/mri.hpp
+++ b/include/natalie_parser/creator/mri.hpp
@@ -75,8 +75,7 @@ public:
     }
 
     virtual void append_symbol(TM::String &name) override {
-        // FIXME: check if there is a way to avoid creation of the Ruby String obj
-        rb_ary_push(m_sexp, ID2SYM(rb_intern_str(rb_str_new(name.c_str(), name.length()))));
+        rb_ary_push(m_sexp, rb_check_id_cstr(name.c_str(), name.length(), NULL));
     }
 
     virtual void append_true() override {


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/c14f230b26aa4f8abe9ecf3814cfebbe584d77c9/symbol.c#L1139-L1148
Note: this creates a fake str as part of the op and returns an id

Tests pass, but TBH I have not looked at the current code coverage to see if that means this change works or not.

Feel free to push back / not accept if this change
  - Does something incorrect that I am missing
  - Decreases performance as I am new to this codebase (and my groking of rb internals).