### PR TITLE
Parse method calls with constant receiver

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2276,6 +2276,15 @@ SharedPtr<NodeWithArgs> Parser::to_node_with_args(SharedPtr<Node> node) {
         };
         return call_node;
     }
+    case Node::Type::Colon2: {
+        auto colon2 = node.static_cast_as<Colon2Node>();
+        auto call_node = new CallNode {
+          colon2->token(),
+          colon2->left(),
+          colon2->name(),
+        };
+        return call_node;
+    }
     case Node::Type::Call:
     case Node::Type::SafeCall:
     case Node::Type::Super:

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -865,6 +865,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse('foo()')).must_equal s(:call, nil, :foo)
         expect(parse("foo ()")).must_equal s(:call, nil, :foo, s(:nil))
         expect(parse('Foo()')).must_equal s(:call, nil, :Foo)
+        expect(parse('Foo::Bar()')).must_equal s(:call, s(:const, :Foo), :Bar)
         expect(parse('foo() + bar()')).must_equal s(:call, s(:call, nil, :foo), :+, s(:call, nil, :bar))
         expect(parse("foo(1, 'baz')")).must_equal s(:call, nil, :foo, s(:lit, 1), s(:str, 'baz'))
         expect(parse('foo(a, b)')).must_equal s(:call, nil, :foo, s(:call, nil, :a), s(:call, nil, :b))


### PR DESCRIPTION
Parsing these currently throws a "left-hand-side is not callable" error.