### PR TITLE
Parse implicit method calls with nth ref argument

### DIFF
--- a/include/natalie_parser/token.hpp
+++ b/include/natalie_parser/token.hpp
@@ -775,6 +775,7 @@ public:
         case Token::Type::NilKeyword:
         case Token::Type::Not:
         case Token::Type::NotKeyword:
+        case Token::Type::NthRef:
         case Token::Type::PercentLowerI:
         case Token::Type::PercentLowerW:
         case Token::Type::PercentUpperI:

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -954,6 +954,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("p Foo:bar")).must_equal s(:call, nil, :p, s(:hash, s(:lit, :Foo), s(:call, nil, :bar)))
         expect(parse("p 'foo':'bar'")).must_equal s(:call, nil, :p, s(:hash, s(:lit, :foo), s(:str, "bar")))
         expect(parse('p "foo":"bar"')).must_equal s(:call, nil, :p, s(:hash, s(:lit, :foo), s(:str, "bar")))
+        expect(parse("p $1")).must_equal s(:call, nil, :p, s(:nth_ref, 1))
         expect(-> { parse("for:bar") }).must_raise SyntaxError # not with a keyword :-)
         # FIXME: colon2 and colon3 are callable
         #expect(parse("Foo::Bar :bar")).must_equal s(:call, s(:const, :Foo), :Bar, s(:lit, :bar))


### PR DESCRIPTION
Before:

    $ ruby -I lib:ext -r natalie_parser -e 'p NatalieParser.parse("puts $1")'
    -e:1:in `parse': (string)#1: syntax error, unexpected 'nth_ref' (expected: 'end-of-line') (SyntaxError)
    puts $1
         ^ here, expected 'end-of-line'
    	from -e:1:in `<main>'

After:

    $ ruby -I lib:ext -r natalie_parser -e 'p NatalieParser.parse("puts $1")'
    s(:call, nil, :puts, s(:nth_ref, 1))

There might be more cases to add, this was just one I found parsing some legacy code 🙂