### PR TITLE
Parse for loops

### DIFF
--- a/include/natalie_parser/node.hpp
+++ b/include/natalie_parser/node.hpp
@@ -31,6 +31,7 @@
 #include "natalie_parser/node/false_node.hpp"
 #include "natalie_parser/node/fixnum_node.hpp"
 #include "natalie_parser/node/float_node.hpp"
+#include "natalie_parser/node/for_node.hpp"
 #include "natalie_parser/node/forward_args_node.hpp"
 #include "natalie_parser/node/hash_node.hpp"
 #include "natalie_parser/node/hash_pattern_node.hpp"

--- a/include/natalie_parser/node/for_node.hpp
+++ b/include/natalie_parser/node/for_node.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "natalie_parser/node/node.hpp"
+#include "natalie_parser/node/node_with_args.hpp"
+#include "natalie_parser/node/block_node.hpp"
+
+namespace NatalieParser {
+
+using namespace TM;
+
+class ForNode : public Node {
+public:
+    ForNode(const Token &token, SharedPtr<Node> expr, SharedPtr<Node> vars, SharedPtr<BlockNode> body)
+        : Node { token }
+        , m_expr { expr }
+        , m_vars { vars }
+        , m_body { body } {
+        assert(m_expr);
+        assert(m_vars);
+    }
+
+    virtual Type type() const override { return Type::For; }
+
+    const SharedPtr<Node> expr() const { return m_expr; }
+    const SharedPtr<Node> vars() const { return m_vars; }
+    const SharedPtr<BlockNode> body() const { return m_body; }
+
+    virtual void transform(Creator *creator) const override {
+        creator->set_type("for");
+        creator->append(m_expr);
+        switch (m_vars->type()) {
+            case Node::Type::Identifier:
+                creator->with_assignment(true, [&]() { creator->append(*m_vars); });
+                break;
+            case Node::Type::MultipleAssignment:
+                creator->append(m_vars);
+                break;
+            default:
+                TM_UNREACHABLE();
+        }
+        if (!m_body->is_empty())
+            creator->append(m_body->without_unnecessary_nesting());
+    }
+
+protected:
+    SharedPtr<Node> m_expr {};
+    SharedPtr<Node> m_vars {};
+    SharedPtr<BlockNode> m_body {};
+};
+}

--- a/include/natalie_parser/node/node.hpp
+++ b/include/natalie_parser/node/node.hpp
@@ -43,6 +43,7 @@ public:
         False,
         Fixnum,
         Float,
+        For,
         ForwardArgs,
         Hash,
         HashPattern,

--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -101,6 +101,7 @@ private:
     SharedPtr<Node> parse_encoding(LocalsHashmap &);
     SharedPtr<Node> parse_end_block(LocalsHashmap &);
     SharedPtr<Node> parse_file_constant(LocalsHashmap &);
+    SharedPtr<Node> parse_for(LocalsHashmap &);
     SharedPtr<Node> parse_forward_args(LocalsHashmap &);
     SharedPtr<Node> parse_group(LocalsHashmap &);
     SharedPtr<Node> parse_hash(LocalsHashmap &);

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1115,6 +1115,14 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse('x = 10; x -= 1 while x.positive?')).must_equal s(:block, s(:lasgn, :x, s(:lit, 10)), s(:while, s(:call, s(:lvar, :x), :positive?), s(:lasgn, :x, s(:call, s(:lvar, :x), :-, s(:lit, 1))), true))
       end
 
+      it 'parses for' do
+        expect(parse('for foo in bar; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
+        expect(parse('for foo in bar; 1; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo), s(:lit, 1))
+        # FIXME: support do keyword
+        # expect(parse('for foo in bar do; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
+        expect(parse('for a, b in c; end')).must_equal s(:for, s(:call, nil, :c), s(:masgn, s(:array, s(:lasgn, :a), s(:lasgn, :b))))
+      end
+
       it 'parses post-conditional if/unless' do
         expect(parse('true if true')).must_equal s(:if, s(:true), s(:true), nil)
         expect(parse('true unless true')).must_equal s(:if, s(:true), nil, s(:true))


### PR DESCRIPTION
Adds support for parsing for loops.

I can't get the optional `do` keyword to parse, so I've added a FIXME test comment for that. 