### PR TITLE
Parse regexps after when keywords

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -264,6 +264,7 @@ Token Lexer::build_next_token() {
         case Token::Type::LParen:
         case Token::Type::Match:
         case Token::Type::Newline:
+        case Token::Type::WhenKeyword:
             return consume_regexp('/', '/');
         case Token::Type::DefKeyword:
             return Token { Token::Type::Slash, m_file, m_token_line, m_token_column, m_whitespace_precedes };

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -122,6 +122,12 @@ describe 'NatalieParser' do
         { type: :string, literal: "/\\*/\\n" }, # eliminates unneeded \\
         { type: :dregxend },
       ]
+      expect(tokenize('when / foo/')).must_equal [
+        { type: :when },
+        { type: :dregx },
+        { type: :string, literal: ' foo' },
+        { type: :dregxend }
+      ]
       expect(tokenize('/foo #{1+1} bar/')).must_equal [
         { type: :dregx },
         { type: :string, literal: 'foo ' },

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1504,6 +1504,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("case\nwhen true then :a\nelse :b\nend")).must_equal s(:case, nil, s(:when, s(:array, s(:true)), s(:lit, :a)), s(:lit, :b))
         expect(parse("case\nfoo; when 1; end")).must_equal s(:case, s(:call, nil, :foo), s(:when, s(:array, s(:lit, 1)), nil), nil)
         expect(parse("case; when 1; end")).must_equal s(:case, nil, s(:when, s(:array, s(:lit, 1)), nil), nil)
+        expect(parse("case; when / foo/; end")).must_equal s(:case, nil, s(:when, s(:array, s(:lit, / foo/)), nil), nil)
         expect(-> { parse("case 1\nelse\n:else\nend") }).must_raise SyntaxError
         expect(-> { parse("case 1\nwhen 1\n1\nelse\n:else\nwhen 2\n2\nend") }).must_raise SyntaxError
         expect(-> { parse("case 1\nelse\n:else\nwhen 2\n2\nend") }).must_raise SyntaxError


### PR DESCRIPTION
Currently raising a syntax error when the regexp has a leading space character:

    $ ruby -I lib:ext -r natalie_parser -e 'p NatalieParser.parse("case 1\nwhen / foo/\nend")' 
    -e:1:in `parse': (string)#2: syntax error, unexpected '/' (expected: 'expression') (SyntaxError)
    when / foo/
         ^ here, expected 'expression'
    	from -e:1:in `<main>'
