### PR TITLE
Parse regexps with leading space preceeded by keywords

### DIFF
--- a/include/natalie_parser/node/match_node.hpp
+++ b/include/natalie_parser/node/match_node.hpp
@@ -13,6 +13,12 @@ using namespace TM;
 
 class MatchNode : public Node {
 public:
+    MatchNode(const Token &token, SharedPtr<RegexpNode> regexp)
+        : Node { token }
+        , m_regexp { regexp } {
+        assert(m_regexp);
+    }
+
     MatchNode(const Token &token, SharedPtr<RegexpNode> regexp, SharedPtr<Node> arg, bool regexp_on_left)
         : Node { token }
         , m_regexp { regexp }

--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -108,6 +108,7 @@ private:
     SharedPtr<Node> parse_hash_inner(LocalsHashmap &, Precedence, Token::Type, bool, SharedPtr<Node> = {});
     SharedPtr<Node> parse_identifier(LocalsHashmap &);
     SharedPtr<Node> parse_if(LocalsHashmap &);
+    SharedPtr<Node> parse_if_branch(LocalsHashmap &, bool);
     void parse_interpolated_body(LocalsHashmap &, InterpolatedNode &, Token::Type);
     SharedPtr<Node> parse_interpolated_regexp(LocalsHashmap &);
     int parse_regexp_options(String &);

--- a/include/natalie_parser/token.hpp
+++ b/include/natalie_parser/token.hpp
@@ -808,6 +808,22 @@ public:
         }
     }
 
+    bool can_precede_regexp_literal() const {
+        switch (m_type) {
+        case Type::ElsifKeyword:
+        case Type::IfKeyword:
+        case Type::RescueKeyword:
+        case Type::ReturnKeyword:
+        case Type::UnlessKeyword:
+        case Type::UntilKeyword:
+        case Type::WhenKeyword:
+        case Type::WhileKeyword:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     bool can_precede_symbol_key() const {
         switch (m_type) {
         case Type::BareName:

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -270,7 +270,11 @@ Token Lexer::build_next_token() {
         default: {
             switch (current_char()) {
             case ' ':
-                return Token { Token::Type::Slash, m_file, m_token_line, m_token_column, m_whitespace_precedes };
+                if (m_last_token.is_keyword() && m_last_token.can_precede_regexp_literal()) {
+                    return consume_regexp('/', '/');
+                } else {
+                    return Token { Token::Type::Slash, m_file, m_token_line, m_token_column, m_whitespace_precedes };
+                }
             case '=':
                 advance();
                 return Token { Token::Type::SlashEqual, m_file, m_token_line, m_token_column, m_whitespace_precedes };

--- a/src/node/match_node.cpp
+++ b/src/node/match_node.cpp
@@ -3,6 +3,11 @@
 namespace NatalieParser {
 
 void MatchNode::transform(Creator *creator) const {
+    if (!m_arg) {
+        creator->set_type("match");
+        creator->append(m_regexp.ref());
+        return;
+    }
     if (m_regexp_on_left)
         creator->set_type("match2");
     else

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2749,6 +2749,9 @@ SharedPtr<Node> Parser::parse_while(LocalsHashmap &locals) {
     auto token = current_token();
     advance();
     SharedPtr<Node> condition = parse_expression(Precedence::LOWEST, locals);
+    if (condition->type() == Node::Type::Regexp) {
+        condition = new MatchNode { condition->token(), condition.static_cast_as<RegexpNode>() };
+    }
     next_expression();
     SharedPtr<BlockNode> body = parse_body(locals, Precedence::LOWEST);
     expect(Token::Type::EndKeyword, "while end");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1363,9 +1363,16 @@ SharedPtr<Node> Parser::parse_identifier(LocalsHashmap &locals) {
 };
 
 SharedPtr<Node> Parser::parse_if(LocalsHashmap &locals) {
+    return parse_if_branch(locals, true);
+}
+
+SharedPtr<Node> Parser::parse_if_branch(LocalsHashmap &locals, bool parse_match_condition) {
     auto token = current_token();
     advance();
     SharedPtr<Node> condition = parse_expression(Precedence::LOWEST, locals);
+    if (parse_match_condition && condition->type() == Node::Type::Regexp) {
+        condition = new MatchNode { condition->token(), condition.static_cast_as<RegexpNode>() };
+    }
     if (current_token().type() == Token::Type::ThenKeyword) {
         advance(); // then
     } else {
@@ -1374,7 +1381,7 @@ SharedPtr<Node> Parser::parse_if(LocalsHashmap &locals) {
     SharedPtr<Node> true_expr = parse_if_body(locals);
     SharedPtr<Node> false_expr;
     if (current_token().is_elsif_keyword()) {
-        false_expr = parse_if(locals);
+        false_expr = parse_if_branch(locals, false);
         return new IfNode { current_token(), condition, true_expr, false_expr };
     } else {
         if (current_token().is_else_keyword()) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2728,6 +2728,9 @@ SharedPtr<Node> Parser::parse_unless(LocalsHashmap &locals) {
     auto token = current_token();
     advance();
     SharedPtr<Node> condition = parse_expression(Precedence::LOWEST, locals);
+    if (condition->type() == Node::Type::Regexp) {
+        condition = new MatchNode { condition->token(), condition.static_cast_as<RegexpNode>() };
+    }
     next_expression();
     SharedPtr<Node> false_expr = parse_if_body(locals);
     SharedPtr<Node> true_expr;

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -167,6 +167,17 @@ describe 'NatalieParser' do
       end
     end
 
+    it 'tokenizes regexps with leading space preceeded by keywords' do
+      %i[elsif if rescue return unless until when while].each do |keyword|
+        expect(tokenize("#{keyword} / foo/")).must_equal [
+          { type: keyword },
+          { type: :dregx },
+          { type: :string, literal: ' foo' },
+          { type: :dregxend }
+        ]
+      end
+    end
+
     it 'tokenizes operators' do
       operators = %w[
         +

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -494,6 +494,17 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse(%(%r"\\\'"))).must_equal s(:lit, /\'/) # %r"\'"
       end
 
+      it 'parses regexps with leading space preceeded by keywords' do
+        expect(parse("if / foo/; end")).must_equal s(:if, s(:match, s(:lit, / foo/)), nil, nil)
+        expect(parse("if false; elsif / foo/; end")).must_equal s(:if, s(:false), nil, s(:if, s(:lit, / foo/), nil, nil))
+        expect(parse("begin; 1; rescue / foo/; end")).must_equal s(:rescue, s(:lit, 1), s(:resbody, s(:array, s(:lit, / foo/)), nil))
+        expect(parse("return / foo/")).must_equal s(:return, s(:lit, / foo/))
+        expect(parse("unless / foo/; end")).must_equal s(:if, s(:match, s(:lit, / foo/)), nil, nil)
+        expect(parse("case; when / foo/; end")).must_equal s(:case, nil, s(:when, s(:array, s(:lit, / foo/)), nil), nil)
+        expect(parse("while / foo/; end")).must_equal s(:while, s(:match, s(:lit, / foo/)), nil, true)
+        expect(parse("until / foo/; end")).must_equal s(:until, s(:match, s(:lit, / foo/)), nil, true)
+      end
+
       it 'parses multiple expressions' do
         expect(parse("1 + 2\n3 + 4")).must_equal s(:block, s(:call, s(:lit, 1), :+, s(:lit, 2)), s(:call, s(:lit, 3), :+, s(:lit, 4)))
         expect(parse("1 + 2;'foo'")).must_equal s(:block, s(:call, s(:lit, 1), :+, s(:lit, 2)), s(:str, 'foo'))


### PR DESCRIPTION
This fixes the lexer to correctly return `:dregx, :string, :dregxend` tokens instead of `:/, :name, :/` for regexps with leading spaces preceeded by keywords, and adds support for parsing `:match` conditions for if, unless, while, and until keywords followed by regexps.