### PR TITLE
Reset block association level inside array

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -354,11 +354,17 @@ SharedPtr<Node> Parser::parse_array(LocalsHashmap &locals) {
         return {};
     };
     auto ret = add_node();
-    if (ret) return ret;
+    if (ret) {
+        m_call_depth.pop();
+        return ret;
+    }
     while (current_token().is_comma()) {
         advance();
         ret = add_node();
-        if (ret) return ret;
+        if (ret) {
+            m_call_depth.pop();
+            return ret;
+        }
     }
     expect(Token::Type::RBracket, "array closing bracket");
     advance(); // ]

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1388,6 +1388,8 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("foo def bar\n x.y do; end\n end")).must_equal s(:call, nil, :foo, s(:defn, :bar, s(:args), s(:iter, s(:call, s(:call, nil, :x), :y), 0)))
         expect(parse("[1,\nfoo do; end,\n 3]")).must_equal s(:array, s(:lit, 1), s(:iter, s(:call, nil, :foo), 0), s(:lit, 3))
         expect(parse("foo(1,\nbar do; end,\n 3)")).must_equal s(:call, nil, :foo, s(:lit, 1), s(:iter, s(:call, nil, :bar), 0), s(:lit, 3))
+        expect(parse("foo do\nbar baz([\n])\nend\nfoo do\nend")).must_equal s(:block, s(:iter, s(:call, nil, :foo), 0, s(:call, nil, :bar, s(:call, nil, :baz, s(:array)))), s(:iter, s(:call, nil, :foo), 0))
+        expect(parse("foo do\nbar baz([\n[ 1, 2 ],\n])\nend\nfoo do\nend")).must_equal s(:block, s(:iter, s(:call, nil, :foo), 0, s(:call, nil, :bar, s(:call, nil, :baz, s(:array, s(:array, s(:lit, 1), s(:lit, 2)))))), s(:iter, s(:call, nil, :foo), 0))
         expect(-> { parse("foo :a { 1 }") }).must_raise SyntaxError
         expect(-> { parse("1 < 2 { 1 }") }).must_raise SyntaxError
         expect(-> { parse("foo 1 < 2 { 3 }") }).must_raise SyntaxError


### PR DESCRIPTION
So I found some code like this:

```ruby
it 'foo' do
  expect(x).to eq(
    [
      [ 1, 2 ],
    ]
  )
end

it 'bar' do
end
```

Current that raises `syntax error, unexpected 'do' (expected: 'end-of-line')` because there's no call to `m_call_depth.pop()` when parsing the array with a trailing comma as there is in the later return.

I've reduced that example as far as I can for the tests, but it needs to have enough structure for the call depth to matter and trigger the bug. I've also added a similar test case and fix for the return statement above the while loop.