### PR TITLE
Parse symbol key after super keyword

### DIFF
--- a/include/natalie_parser/token.hpp
+++ b/include/natalie_parser/token.hpp
@@ -834,6 +834,7 @@ public:
         case Type::LParen:
         case Type::Pipe:
         case Type::PipePipe:
+        case Type::SuperKeyword:
             return true;
         default:
             return false;

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -787,6 +787,7 @@ describe 'NatalieParser' do
       expect(tokenize("{\nfoo:bar}")).must_include(type: :symbol_key, literal: :foo)
       expect(tokenize('Hash[foo:bar]')).must_include(type: :symbol_key, literal: :foo)
       expect(tokenize('Hash[foo: bar]')).must_include(type: :symbol_key, literal: :foo)
+      expect(tokenize('super foo:bar')).must_include(type: :symbol_key, literal: :foo)
     end
 
     it 'tokenizes local variables' do

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1434,6 +1434,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse('super()')).must_equal s(:super)
         expect(parse('super 1')).must_equal s(:super, s(:lit, 1))
         expect(parse('super 1, 2')).must_equal s(:super, s(:lit, 1), s(:lit, 2))
+        expect(parse('super a: b')).must_equal s(:super, s(bare_hash_type, s(:lit, :a), s(:call, nil, :b)))
         expect(parse('super([1, 2])')).must_equal s(:super, s(:array, s(:lit, 1), s(:lit, 2)))
         expect(parse('super if true')).must_equal s(:if, s(:true), s(:zsuper), nil)
         expect(parse('foo { super }')).must_equal s(:iter, s(:call, nil, :foo), 0, s(:zsuper))


### PR DESCRIPTION
Currently failing to parse super calls without parentheses:

    $ ruby -I lib:ext -r natalie_parser -e 'p NatalieParser.parse("super a: 1")' 
    -e:1:in `parse': (string)#1: syntax error, unexpected ':' (expected: 'expression') (SyntaxError)
    super a: 1
           ^ here, expected 'expression'
    	from -e:1:in `<main>'
