### PR TITLE
Parse global variables beginning with `$_`

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1157,7 +1157,6 @@ Token Lexer::consume_global_variable() {
     case '.':
     case ',':
     case ':':
-    case '_':
     case '~': {
         advance();
         SharedPtr<String> buf = new String("$");

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -806,6 +806,7 @@ describe 'NatalieParser' do
     it 'tokenizes global variables' do
       expect(tokenize('$foo')).must_equal [{ type: :gvar, literal: :$foo }]
       expect(tokenize('$0')).must_equal [{ type: :gvar, literal: :$0 }]
+      expect(tokenize('$__a')).must_equal [{ type: :gvar, literal: :$__a }]
       %i[$? $! $= $~ $@ $` $' $+ $/ $\\ $; $< $> $$ $* $. $: $" $_ $,].each do |sym|
         expect(tokenize(sym.to_s)).must_equal [{ type: :gvar, literal: sym }]
       end


### PR DESCRIPTION
Hello again :) Deleted `case '_'` in lexer.cpp since the `default` case can already handle underscores 🚀