### PR TITLE
Parse multiple parameters set to the same default value

### DIFF
--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -97,6 +97,7 @@ private:
         Proc,
     };
     void parse_def_single_arg(Vector<SharedPtr<Node>> &, LocalsHashmap &, ArgsContext);
+    SharedPtr<Node> parse_arg_default_value(LocalsHashmap &);
 
     SharedPtr<Node> parse_encoding(LocalsHashmap &);
     SharedPtr<Node> parse_end_block(LocalsHashmap &);

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -683,6 +683,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse('def foo(a = nil, b = foo, c = FOO); end')).must_equal s(:defn, :foo, s(:args, s(:lasgn, :a, s(:nil)), s(:lasgn, :b, s(:call, nil, :foo)), s(:lasgn, :c, s(:const, :FOO))), s(:nil))
         expect(parse('bar def foo() end')).must_equal s(:call, nil, :bar, s(:defn, :foo, s(:args), s(:nil)))
         expect(parse('def (@foo = bar).===(obj); end')).must_equal s(:defs, s(:iasgn, :@foo, s(:call, nil, :bar)), :===, s(:args, :obj), s(:nil))
+        expect(parse('def foo(a=b=c={}); c; end')).must_equal s(:defn, :foo, s(:args, s(:lasgn, :a, s(:lasgn, :b, s(:lasgn, :c, s(:hash))))), s(:lvar, :c))
 
         # args in wrong order
         expect(-> { parse('def foo(a, *b, c = nil) end') }).must_raise SyntaxError


### PR DESCRIPTION
Relevant spec: https://github.com/ruby/spec/blob/8d26c0c/language/def_spec.rb#L747-L782

I'm not sure why this exists, but... it does 🤯