### PR TITLE
Use Precedence::LOWEST for block pass

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -501,7 +501,7 @@ SharedPtr<Node> Parser::parse_beginless_range(LocalsHashmap &locals) {
 SharedPtr<Node> Parser::parse_block_pass(LocalsHashmap &locals) {
     auto token = current_token();
     advance();
-    auto value = parse_expression(Precedence::UNARY_PLUS, locals);
+    auto value = parse_expression(Precedence::LOWEST, locals);
     return new BlockPassNode { token, value };
 }
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1414,6 +1414,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse('map(&:foo)')).must_equal s(:call, nil, :map, s(:block_pass, s(:lit, :foo)))
         expect(parse('map(&myblock)')).must_equal s(:call, nil, :map, s(:block_pass, s(:call, nil, :myblock)))
         expect(parse('map(&nil)')).must_equal s(:call, nil, :map, s(:block_pass, s(:nil)))
+        expect(parse('map(&5.method(:+))')).must_equal s(:call, nil, :map, s(:block_pass, s(:call, s(:lit, 5), :method, s(:lit, :+))))
       end
 
       it 'parses break, next, super, and yield' do


### PR DESCRIPTION
It seems like we should use a lower precedence to correctly pass expressions as blocks. For example:

```
[].map(&5.method(:+))
```

should be call `#method` on 5 and pass this as a block.