### PR TITLE
Parse `for ... do` and `while ... do`

### DIFF
--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -52,13 +52,13 @@ public:
     SharedPtr<Node> tree();
 
 private:
-    bool higher_precedence(Token &token, SharedPtr<Node> left, Precedence current_precedence);
+    bool higher_precedence(Token &token, SharedPtr<Node> left, Precedence current_precedence, bool allow_block);
 
     Precedence get_precedence(Token &token, SharedPtr<Node> left = {});
 
     bool is_first_arg_of_call_without_parens(SharedPtr<Node>, Token &);
 
-    SharedPtr<Node> parse_expression(Precedence, LocalsHashmap &);
+    SharedPtr<Node> parse_expression(Precedence, LocalsHashmap &, bool = true);
 
     SharedPtr<BlockNode> parse_body(LocalsHashmap &, Precedence, std::function<bool(Token::Type)>, bool = false);
     SharedPtr<BlockNode> parse_body(LocalsHashmap &, Precedence, Token::Type = Token::Type::EndKeyword, bool = false);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -46,7 +46,7 @@ enum class Parser::Precedence {
     REF, // foo[1] / foo[1] = 2
 };
 
-bool Parser::higher_precedence(Token &token, SharedPtr<Node> left, Precedence current_precedence) {
+bool Parser::higher_precedence(Token &token, SharedPtr<Node> left, Precedence current_precedence, bool allow_block) {
     auto next_precedence = get_precedence(token, left);
 
     // printf("token %d, left %d, current_precedence %d, next_precedence %d\n", (int)token.type(), (int)left->type(), (int)current_precedence, (int)next_precedence);
@@ -83,7 +83,7 @@ bool Parser::higher_precedence(Token &token, SharedPtr<Node> left, Precedence cu
         // NOTE: `m_call_depth` should probably be called
         // `m_call_that_can_accept_a_block_depth`, but that's a bit long.
         //
-        return m_call_depth.last() == 0;
+        return allow_block && m_call_depth.last() == 0;
     }
 
     if (next_precedence == Precedence::ITER_CURLY)
@@ -198,7 +198,7 @@ Parser::Precedence Parser::get_precedence(Token &token, SharedPtr<Node> left) {
     return Precedence::LOWEST;
 }
 
-SharedPtr<Node> Parser::parse_expression(Parser::Precedence precedence, LocalsHashmap &locals) {
+SharedPtr<Node> Parser::parse_expression(Parser::Precedence precedence, LocalsHashmap &locals, bool allow_block) {
     skip_newlines();
 
     m_precedence_stack.push(precedence);
@@ -211,7 +211,7 @@ SharedPtr<Node> Parser::parse_expression(Parser::Precedence precedence, LocalsHa
 
     while (current_token().is_valid()) {
         auto token = current_token();
-        if (!higher_precedence(token, left, precedence))
+        if (!higher_precedence(token, left, precedence, allow_block))
             break;
         auto left_fn = left_denotation(token, left, precedence);
         if (!left_fn)
@@ -1292,7 +1292,10 @@ SharedPtr<Node> Parser::parse_for(LocalsHashmap &locals) {
     }
     expect(Token::Type::InKeyword, "for in");
     advance();
-    auto expr = parse_expression(Precedence::LOWEST, locals);
+    auto expr = parse_expression(Precedence::LOWEST, locals, false);
+    if (current_token().type() == Token::Type::DoKeyword) {
+        advance();
+    }
     auto body = parse_body(locals, Precedence::LOWEST);
     expect(Token::Type::EndKeyword, "for end");
     advance();
@@ -2782,11 +2785,15 @@ SharedPtr<Node> Parser::parse_unless(LocalsHashmap &locals) {
 SharedPtr<Node> Parser::parse_while(LocalsHashmap &locals) {
     auto token = current_token();
     advance();
-    SharedPtr<Node> condition = parse_expression(Precedence::LOWEST, locals);
+    SharedPtr<Node> condition = parse_expression(Precedence::LOWEST, locals, false);
     if (condition->type() == Node::Type::Regexp) {
         condition = new MatchNode { condition->token(), condition.static_cast_as<RegexpNode>() };
     }
-    next_expression();
+    if (current_token().type() == Token::Type::DoKeyword) {
+        advance();
+    } else {
+        next_expression();
+    }
     SharedPtr<BlockNode> body = parse_body(locals, Precedence::LOWEST);
     expect(Token::Type::EndKeyword, "while end");
     advance();

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1110,9 +1110,13 @@ require_relative '../lib/natalie_parser/sexp'
       it 'parses while/until' do
         expect(parse('while true; end')).must_equal s(:while, s(:true), nil, true)
         expect(parse('while true; 1; end')).must_equal s(:while, s(:true), s(:lit, 1), true)
+        expect(parse('while true do end')).must_equal s(:while, s(:true), nil, true)
+        expect(parse('while true do 1; end')).must_equal s(:while, s(:true), s(:lit, 1), true)
         expect(parse('while true; 1; 2; end')).must_equal s(:while, s(:true), s(:block, s(:lit, 1), s(:lit, 2)), true)
         expect(parse('until true; end')).must_equal s(:until, s(:true), nil, true)
         expect(parse('until true; 1; end')).must_equal s(:until, s(:true), s(:lit, 1), true)
+        expect(parse('until true do end')).must_equal s(:until, s(:true), nil, true)
+        expect(parse('until true do 1; end')).must_equal s(:until, s(:true), s(:lit, 1), true)
         expect(parse('until true; 1; 2; end')).must_equal s(:until, s(:true), s(:block, s(:lit, 1), s(:lit, 2)), true)
         expect(parse('foo while true')).must_equal s(:while, s(:true), s(:call, nil, :foo), true)
         expect(parse('begin; foo; end while true')).must_equal s(:while, s(:true), s(:call, nil, :foo), false)
@@ -1132,6 +1136,8 @@ require_relative '../lib/natalie_parser/sexp'
       it 'parses for' do
         expect(parse('for foo in bar; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
         expect(parse('for foo in bar; 1; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo), s(:lit, 1))
+        expect(parse('for foo in bar do end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
+        expect(parse('for foo in bar do 1; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo), s(:lit, 1))
         # FIXME: support do keyword
         # expect(parse('for foo in bar do; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
         expect(parse('for a, b in c; end')).must_equal s(:for, s(:call, nil, :c), s(:masgn, s(:array, s(:lasgn, :a), s(:lasgn, :b))))


### PR DESCRIPTION
`for foo in bar do baz; end` should be parsed as `for foo in bar; baz; end`, not `for foo in (bar { baz })`