### PR TITLE
Parse variable names starting with extended ASCII characters

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -83,6 +83,11 @@ Token Lexer::next_token() {
     return build_next_token();
 }
 
+bool is_name_start_char(char c) {
+    if (!c) return false;
+    return (c >= 'a' && c <= 'z') || c == '_' || (unsigned int)c >= 128;
+}
+
 bool is_identifier_char(char c) {
     if (!c) return false;
     return isalnum(c) || c == '_' || (unsigned int)c >= 128;
@@ -795,7 +800,7 @@ Token Lexer::build_next_token() {
     }
 
     auto c = current_char();
-    if ((c >= 'a' && c <= 'z') || c == '_') {
+    if (is_name_start_char(c)) {
         return consume_bare_name();
     } else if (c >= 'A' && c <= 'Z') {
         return consume_constant();

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -1194,5 +1194,10 @@ describe 'NatalieParser' do
         { type: :name, literal: :baz, line: 2, column: 4 },
       ]
     end
+
+    it 'tokenizes names starting with extended ASCII characters' do
+      expect(tokenize('ë')).must_equal [{:type=>:name, :literal=>:ë}]
+      expect(tokenize('öld')).must_equal [{:type=>:name, :literal=>:öld}]
+    end
   end
 end


### PR DESCRIPTION
Added a missing `(unsigned int)c >= 128` check that allows variables to start with extended ASCII characters like `ë`