### PR TITLE
Parse class/module definition in dynamic class/module

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -865,15 +865,19 @@ SharedPtr<BlockNode> Parser::parse_case_when_body(LocalsHashmap &locals) {
 }
 
 SharedPtr<Node> Parser::parse_class_or_module_name(LocalsHashmap &locals) {
-    Token name_token;
-    if (current_token().type() == Token::Type::ConstantResolution) {
-        name_token = peek_token();
-    } else {
-        name_token = current_token();
-    }
-    if (name_token.type() != Token::Type::Constant)
+    auto name_token = current_token();
+    auto exp = parse_expression(Precedence::LESS_GREATER, locals);
+    switch (exp->type()) {
+    case Node::Type::Colon2:
+    case Node::Type::Colon3:
+        return exp;
+    case Node::Type::Identifier:
+        if (name_token.type() == Token::Type::Constant)
+            return exp;
+        [[fallthrough]];
+    default:
         throw SyntaxError { "class/module name must be CONSTANT" };
-    return parse_expression(Precedence::LESS_GREATER, locals);
+    }
 }
 
 SharedPtr<Node> Parser::parse_class(LocalsHashmap &locals) {

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1158,6 +1158,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("class Foo < Bar; 3\n 4\n end")).must_equal s(:class, :Foo, s(:const, :Bar), s(:lit, 3), s(:lit, 4))
         expect(parse("class Foo < bar; 3\n 4\n end")).must_equal s(:class, :Foo, s(:call, nil, :bar), s(:lit, 3), s(:lit, 4))
         expect(parse('class Foo::Bar; end')).must_equal s(:class, s(:colon2, s(:const, :Foo), :Bar), nil)
+        expect(parse('class foo::Bar; end')).must_equal s(:class, s(:colon2, s(:call, nil, :foo), :Bar), nil)
         expect(parse('class ::Foo; end')).must_equal s(:class, s(:colon3, :Foo), nil)
       end
 
@@ -1173,6 +1174,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse('module FooBar; 1; 2; end')).must_equal s(:module, :FooBar, s(:lit, 1), s(:lit, 2))
         expect_raise_with_message(-> { parse('module foo;end') }, SyntaxError, 'class/module name must be CONSTANT')
         expect(parse('module Foo::Bar; end')).must_equal s(:module, s(:colon2, s(:const, :Foo), :Bar))
+        expect(parse('module foo::Bar; end')).must_equal s(:module, s(:colon2, s(:call, nil, :foo), :Bar))
         expect(parse('module ::Foo; end')).must_equal s(:module, s(:colon3, :Foo))
       end
 


### PR DESCRIPTION
For example:

```rb
m = Module.new
module m::N; end
```