### PR TITLE
Parse aliases of unary operators and methods named as keywords

### DIFF
--- a/include/natalie_parser/lexer.hpp
+++ b/include/natalie_parser/lexer.hpp
@@ -138,5 +138,7 @@ protected:
     // then increment m_pair_depth
     char m_start_char { 0 };
     int m_pair_depth { 0 };
+
+    size_t m_remaining_method_names { 0 };
 };
 }

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -1004,6 +1004,43 @@ describe 'NatalieParser' do
       expect(tokenize("foo.%(x)")).must_equal [{ type: :name, literal: :foo }, { type: :"." }, { type: :% }, { type: :"(" }, { type: :name, literal: :x }, { type: :")" }]
     end
 
+    it 'tokenizes method aliases' do
+      %i[+@ -@ ~@ !@].each do |op|
+        expect(tokenize("alias #{op} foo")).must_equal [{:type=>:alias}, {:type=>:name, :literal=>op}, {:type=>:name, :literal=>:foo}]
+        expect(tokenize("alias foo #{op}")).must_equal [{:type=>:alias}, {:type=>:name, :literal=>:foo}, {:type=>:name, :literal=>op}]
+      end
+      %i(& ^ <=> == === > >= [] []= << < <= =~ - != !~ % | + >> / * ** ~).each do |op|
+        expect(tokenize("alias #{op} foo")).must_equal [{:type=>:alias}, {:type=>op}, {:type=>:name, :literal=>:foo}]
+        expect(tokenize("alias foo #{op}")).must_equal [{:type=>:alias}, {:type=>:name, :literal=>:foo}, {:type=>op}]
+      end
+      %i[BEGIN END].each do |keyword|
+        expect(tokenize("alias #{keyword} foo")).must_equal [{:type=>:alias}, {:type=>:constant, :literal=>keyword}, {:type=>:name, :literal=>:foo}]
+        expect(tokenize("alias foo #{keyword}")).must_equal [{:type=>:alias}, {:type=>:name, :literal=>:foo}, {:type=>:constant, :literal=>keyword}]
+      end
+      %i[
+        __ENCODING__ __LINE__ __FILE__
+        alias and
+        begin break
+        case class
+        defined? def do
+        else elsif end ensure
+        false for
+        if in
+        module
+        next nil not
+        or
+        redo rescue retry return
+        self super
+        then true
+        undef unless until
+        when while
+        yield
+      ].each do |keyword|
+        expect(tokenize("alias #{keyword} foo")).must_equal [{:type=>:alias}, {:type=>:name, :literal=>keyword}, {:type=>:name, :literal=>:foo}]
+        expect(tokenize("alias foo #{keyword}")).must_equal [{:type=>:alias}, {:type=>:name, :literal=>:foo}, {:type=>:name, :literal=>keyword}]
+      end
+    end
+
     it 'tokenizes argument forwarding shorthand' do
       expect(tokenize("...")).must_equal [{ type: :'...' }]
     end


### PR DESCRIPTION
Added a `m_remaining_method_names` field to the `Lexer` class so that instead of checking if the last token was `alias`, `def`, or `.`, we can just check if `m_remaining_method_names` is greater than zero.

(This didn't turn out as bad as I thought would, so I've changed my mind about [merging the lexer and parser](https://github.com/natalie-lang/natalie_parser/pull/22#issuecomment-1272227536))