### PR TITLE
Parse some more percent strings

### DIFF
--- a/include/natalie_parser/lexer.hpp
+++ b/include/natalie_parser/lexer.hpp
@@ -85,13 +85,14 @@ protected:
     Token consume_quoted_array_without_interpolation(char start_char, char stop_char, Token::Type type);
     Token consume_quoted_array_with_interpolation(char start_char, char stop_char, Token::Type type);
     Token consume_regexp(char start_char, char stop_char);
+    Token consume_percent_symbol(char start_char, char stop_char);
     Token consume_interpolated_string(char start_char, char stop_char);
     Token consume_interpolated_shell(char start_char, char stop_char);
     Token consume_percent_lower_w(char start_char, char stop_char);
     Token consume_percent_upper_w(char start_char, char stop_char);
     Token consume_percent_lower_i(char start_char, char stop_char);
     Token consume_percent_upper_i(char start_char, char stop_char);
-    Token consume_percent_string(Token (Lexer::*consumer)(char start_char, char stop_char));
+    Token consume_percent_string(Token (Lexer::*consumer)(char start_char, char stop_char), bool is_lettered = true);
     SharedPtr<String> consume_non_whitespace();
 
     void utf32_codepoint_to_utf8(String &buf, long long codepoint);
@@ -102,7 +103,7 @@ protected:
     bool token_is_first_on_line() const;
 
     bool char_can_be_string_or_regexp_delimiter(char c) const {
-        return (c >= '!' && c <= '/') || c == ':' || c == '?' || c == '@' || c == '~' || c == '|' || (c >= '^' && c <= '`');
+        return (c >= '!' && c <= '/') || c == ':' || c == ';' || c == '=' || c == '?' || c == '@' || c == '\\' || c == '~' || c == '|' || (c >= '^' && c <= '`');
     }
 
     SharedPtr<String> m_input;

--- a/src/lexer/interpolated_string_lexer.cpp
+++ b/src/lexer/interpolated_string_lexer.cpp
@@ -22,7 +22,7 @@ Token InterpolatedStringLexer::build_next_token() {
 Token InterpolatedStringLexer::consume_string() {
     SharedPtr<String> buf = new String;
     while (auto c = current_char()) {
-        if (c == '\\') {
+        if (c == '\\' && m_stop_char != '\\') {
             advance(); // backslash
             auto result = consume_escaped_byte(*buf);
             if (!result.first)

--- a/src/lexer/regexp_lexer.cpp
+++ b/src/lexer/regexp_lexer.cpp
@@ -38,7 +38,7 @@ Token RegexpLexer::build_next_token() {
 Token RegexpLexer::consume_regexp() {
     SharedPtr<String> buf = new String;
     while (auto c = current_char()) {
-        if (c == '\\') {
+        if (c == '\\' && m_stop_char != '\\') {
             c = next();
             switch (c) {
             case '/':

--- a/src/lexer/word_array_lexer.cpp
+++ b/src/lexer/word_array_lexer.cpp
@@ -38,7 +38,7 @@ Token WordArrayLexer::build_next_token() {
 Token WordArrayLexer::consume_array() {
     m_buffer = new String;
     while (auto c = current_char()) {
-        if (c == '\\') {
+        if (c == '\\' && m_stop_char != '\\') {
             c = next();
             advance();
             if (c == ' ') {


### PR DESCRIPTION
- Parse `%s(symbol)`
- Allow semicolon (`;`), equal sign (`=`), and backslash (`\`) as delimiters