### PR TITLE
Parse alias/undef of assignment methods

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -311,16 +311,14 @@ SharedPtr<SymbolNode> Parser::parse_alias_arg(LocalsHashmap &locals, const char 
     case Token::Type::BareName:
     case Token::Type::Constant:
     case Token::Type::OperatorName:
-        advance();
-        return new SymbolNode { token, token.literal_string() };
+        return new SymbolNode { token, parse_method_name(locals) };
     case Token::Type::Symbol:
         return parse_symbol(locals).static_cast_as<SymbolNode>();
     case Token::Type::InterpolatedSymbolBegin:
         return parse_interpolated_symbol(locals).static_cast_as<SymbolNode>();
     default:
         if (token.is_operator() || token.is_keyword()) {
-            advance();
-            return new SymbolNode { token, new String(token.type_value()) };
+            return new SymbolNode { token, parse_method_name(locals) };
         } else {
             throw_unexpected(expected_message);
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1035,10 +1035,6 @@ SharedPtr<Node> Parser::parse_def(LocalsHashmap &locals) {
         }
     }
     }
-    if (current_token().is_equal() && !current_token().whitespace_precedes()) {
-        advance();
-        name->append_char('=');
-    }
     auto args = Vector<SharedPtr<Node>> {};
     if (current_token().is_lparen()) {
         advance();
@@ -1725,20 +1721,31 @@ SharedPtr<Node> Parser::parse_keyword_splat(LocalsHashmap &locals) {
 
 SharedPtr<String> Parser::parse_method_name(LocalsHashmap &) {
     SharedPtr<String> name = new String("");
+    bool assignable;
     auto token = current_token();
     switch (token.type()) {
     case Token::Type::BareName:
     case Token::Type::Constant:
+        name = current_token().literal_string();
+        assignable = true;
+        break;
     case Token::Type::OperatorName:
         name = current_token().literal_string();
+        assignable = false;
         break;
     default:
-        if (token.is_operator() || token.is_keyword())
+        if (token.is_operator() || token.is_keyword()) {
             name = new String(current_token().type_value());
-        else
+            assignable = token.is_keyword();
+        } else {
             throw_unexpected("method name");
+        }
     }
     advance();
+    if (assignable && current_token().is_equal() && !current_token().whitespace_precedes()) {
+        advance();
+        name->append_char('=');
+    }
     return name;
 }
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -709,6 +709,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse('def foo = bar')).must_equal s(:defn, :foo, s(:args), s(:call, nil, :bar))
         expect(parse('def self.exec(cmd) = system(cmd) rescue nil')).must_equal s(:defs, s(:self), :exec, s(:args, :cmd), s(:rescue, s(:call, nil, :system, s(:lvar, :cmd)), s(:resbody, s(:array), s(:nil))))
         expect(parse("def ==(o) = 42")).must_equal s(:defn, :==, s(:args, :o), s(:lit, 42))
+        expect(-> { parse("def ====; end") }).must_raise SyntaxError
         expect(parse("def self.==(o) = 42")).must_equal s(:defs, s(:self), :==, s(:args, :o), s(:lit, 42))
         expect(-> { parse('def foo a, b = bar') }).must_raise SyntaxError
         expect_raise_with_message(-> { parse("def self.x=(o) = 42") }, SyntaxError, "setter method cannot be defined in an endless method definition")

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -733,6 +733,11 @@ require_relative '../lib/natalie_parser/sexp'
         multiple_args_result = parse('undef foo, :bar')
         expect(multiple_args_result).must_equal s(:block, s(:undef, s(:lit, :foo)), s(:undef, s(:lit, :bar)))
         expect(parse("undef <<\ndef foo; end")).must_equal s(:block, s(:undef, s(:lit, :<<)), s(:defn, :foo, s(:args), s(:nil)))
+        if parser == 'NatalieParser'
+          expect(parse("undef foo=, and=\ndef foo; end")).must_equal s(:block, s(:block, s(:undef, s(:lit, :foo=)), s(:undef, s(:lit, :and=))), s(:defn, :foo, s(:args), s(:nil)))
+        else
+          expect(parse("undef foo=, and=\ndef foo; end")).must_equal s(:block, s(:undef, s(:lit, :foo=)), s(:undef, s(:lit, :and=)), s(:defn, :foo, s(:args), s(:nil)))
+        end
       end
 
       it 'parses operator method definitions' do
@@ -1678,6 +1683,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("alias << write\ndef foo; end")).must_equal s(:block, s(:alias, s(:lit, :<<), s(:lit, :write)), s(:defn, :foo, s(:args), s(:nil)))
         expect(parse("alias yield <<\ndef foo; end")).must_equal s(:block, s(:alias, s(:lit, :yield), s(:lit, :<<)), s(:defn, :foo, s(:args), s(:nil)))
         expect(parse("alias << yield\ndef foo; end")).must_equal s(:block, s(:alias, s(:lit, :<<), s(:lit, :yield)), s(:defn, :foo, s(:args), s(:nil)))
+        expect(parse("alias foo= and=\ndef foo; end")).must_equal s(:block, s(:alias, s(:lit, :foo=), s(:lit, :and=)), s(:defn, :foo, s(:args), s(:nil)))
       end
 
       it 'parses defined?' do


### PR DESCRIPTION
Also raise SyntaxError for `def ====`