### PR TITLE
Fix lexing of symbol keys with trailing punctuation

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -975,6 +975,10 @@ Token Lexer::consume_bare_name_or_constant(Token::Type type) {
     switch (c) {
     case '?':
     case '!':
+        if (peek() == ':' && m_last_token.can_precede_symbol_key()) {
+            advance();
+            type = Token::Type::SymbolKey;
+        }
         advance();
         buf->append_char(c);
         break;

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -820,6 +820,8 @@ describe 'NatalieParser' do
       expect(tokenize('p{|x|foo:bar}')).must_include(type: :symbol_key, literal: :foo)
       expect(tokenize('p{||foo:bar}')).must_include(type: :symbol_key, literal: :foo)
       expect(tokenize("{\nfoo:bar}")).must_include(type: :symbol_key, literal: :foo)
+      expect(tokenize("{\nfoo?:bar}")).must_include(type: :symbol_key, literal: :foo?)
+      expect(tokenize("{\nfoo!:bar}")).must_include(type: :symbol_key, literal: :foo!)
       expect(tokenize('Hash[foo:bar]')).must_include(type: :symbol_key, literal: :foo)
       expect(tokenize('Hash[foo: bar]')).must_include(type: :symbol_key, literal: :foo)
       expect(tokenize('super foo:bar')).must_include(type: :symbol_key, literal: :foo)


### PR DESCRIPTION
Since 528c33c these aren't parsing because the lexer is returning `{:type=>:name, :literal=>:a?}, {:type=>:":"}` instead of `{:type=>:symbol_key, :literal=>:a?}`