### PR TITLE
Various for loop improvements

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1300,6 +1300,16 @@ SharedPtr<Node> Parser::parse_for(LocalsHashmap &locals) {
     if (current_token().is_comma() || vars->type() == Node::Type::Splat) {
         vars = parse_multiple_assignment_expression(vars, locals);
     }
+    switch (vars->type()) {
+    case Node::Type::Identifier:
+        vars.static_cast_as<IdentifierNode>()->add_to_locals(locals);
+        break;
+    case Node::Type::MultipleAssignment:
+        vars.static_cast_as<MultipleAssignmentNode>()->add_locals(locals);
+        break;
+    default:
+        break;
+    }
     expect(Token::Type::InKeyword, "for in");
     advance();
     m_call_depth.last()++;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -910,7 +910,7 @@ SharedPtr<Node> Parser::parse_multiple_assignment_expression(SharedPtr<Node> lef
     list->add_node(left);
     while (current_token().is_comma()) {
         advance();
-        if (current_token().is_rparen() || current_token().is_equal()) {
+        if (current_token().is_rparen() || current_token().is_equal() || current_token().type() == Token::Type::InKeyword) {
             // trailing comma with no additional identifier
             break;
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1296,8 +1296,8 @@ SharedPtr<Node> Parser::parse_line_constant(LocalsHashmap &) {
 SharedPtr<Node> Parser::parse_for(LocalsHashmap &locals) {
     auto token = current_token();
     advance();
-    auto vars = parse_assignment_identifier(false, locals);
-    if (current_token().type() == Token::Type::Comma) {
+    auto vars = parse_assignment_identifier(true, locals);
+    if (current_token().is_comma() || vars->type() == Node::Type::Splat) {
         vars = parse_multiple_assignment_expression(vars, locals);
     }
     expect(Token::Type::InKeyword, "for in");

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1152,6 +1152,7 @@ require_relative '../lib/natalie_parser/sexp'
 
       it 'parses for' do
         expect(parse('for foo in bar; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
+        expect(parse('for *foo in bar; end')).must_equal s(:for, s(:call, nil, :bar), s(:masgn, s(:array, s(:splat, s(:lasgn, :foo)))))
         expect(parse('for foo in bar; 1; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo), s(:lit, 1))
         expect(parse('for foo in bar do end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
         expect(parse('for foo in bar do 1; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo), s(:lit, 1))

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1161,6 +1161,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("for foo in bar do\nend")).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
         expect(parse("for foo in 1...height do\nend")).must_equal s(:for, s(:dot3, s(:lit, 1), s(:call, nil, :height)), s(:lasgn, :foo))
         expect(parse('for a, b in c; end')).must_equal s(:for, s(:call, nil, :c), s(:masgn, s(:array, s(:lasgn, :a), s(:lasgn, :b))))
+        expect(parse('for a, b, in c; end')).must_equal s(:for, s(:call, nil, :c), s(:masgn, s(:array, s(:lasgn, :a), s(:lasgn, :b))))
         expect(parse('for a, b in c; a; end')).must_equal s(:for, s(:call, nil, :c), s(:masgn, s(:array, s(:lasgn, :a), s(:lasgn, :b))), s(:lvar, :a))
       end
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1152,6 +1152,7 @@ require_relative '../lib/natalie_parser/sexp'
 
       it 'parses for' do
         expect(parse('for foo in bar; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
+        expect(parse('for foo in bar; foo; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo), s(:lvar, :foo))
         expect(parse('for *foo in bar; end')).must_equal s(:for, s(:call, nil, :bar), s(:masgn, s(:array, s(:splat, s(:lasgn, :foo)))))
         expect(parse('for foo in bar; 1; end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo), s(:lit, 1))
         expect(parse('for foo in bar do end')).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
@@ -1160,6 +1161,7 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("for foo in bar do\nend")).must_equal s(:for, s(:call, nil, :bar), s(:lasgn, :foo))
         expect(parse("for foo in 1...height do\nend")).must_equal s(:for, s(:dot3, s(:lit, 1), s(:call, nil, :height)), s(:lasgn, :foo))
         expect(parse('for a, b in c; end')).must_equal s(:for, s(:call, nil, :c), s(:masgn, s(:array, s(:lasgn, :a), s(:lasgn, :b))))
+        expect(parse('for a, b in c; a; end')).must_equal s(:for, s(:call, nil, :c), s(:masgn, s(:array, s(:lasgn, :a), s(:lasgn, :b))), s(:lvar, :a))
       end
 
       it 'parses post-conditional if/unless' do


### PR DESCRIPTION
Parse for loop with splat assignment:

```rb
for *foo in bar; end
```

Add for loop variables to local scope:

```rb
for foo in bar; foo; end
```

Allow trailing comma after for loop variables:

```rb
for a, b, in c; end
```