### PR TITLE
Allow non-local variable in rescue

### DIFF
--- a/include/natalie_parser/node/begin_rescue_node.hpp
+++ b/include/natalie_parser/node/begin_rescue_node.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "natalie_parser/node/block_node.hpp"
-#include "natalie_parser/node/identifier_node.hpp"
 #include "natalie_parser/node/node.hpp"
 #include "natalie_parser/node/node_with_args.hpp"
 #include "tm/hashmap.hpp"
@@ -23,24 +22,24 @@ public:
         m_exceptions.push(node);
     }
 
-    void set_exception_name(SharedPtr<IdentifierNode> name) {
+    void set_exception_name(SharedPtr<Node> name) {
         m_name = name;
     }
 
     void set_body(SharedPtr<BlockNode> body) { m_body = body; }
 
-    SharedPtr<Node> name_to_node() const;
+    SharedPtr<Node> name_to_assignment() const;
 
     bool has_name() const { return m_name; }
 
-    const SharedPtr<IdentifierNode> name() const { return m_name; }
+    const SharedPtr<Node> name() const { return m_name; }
     const Vector<SharedPtr<Node>> &exceptions() const { return m_exceptions; }
     const SharedPtr<BlockNode> body() const { return m_body; }
 
     virtual void transform(Creator *creator) const override;
 
 protected:
-    SharedPtr<IdentifierNode> m_name {};
+    SharedPtr<Node> m_name {};
     Vector<SharedPtr<Node>> m_exceptions {};
     SharedPtr<BlockNode> m_body {};
 };

--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -161,6 +161,7 @@ private:
     SharedPtr<Node> parse_assignment_expression(SharedPtr<Node>, LocalsHashmap &);
     SharedPtr<Node> parse_assignment_expression_without_multiple_values(SharedPtr<Node>, LocalsHashmap &);
     SharedPtr<Node> parse_assignment_expression(SharedPtr<Node>, LocalsHashmap &, bool);
+    void add_assignment_locals(SharedPtr<Node>, LocalsHashmap &);
     SharedPtr<Node> parse_assignment_expression_value(bool, LocalsHashmap &, bool);
     SharedPtr<Node> parse_assignment_identifier(bool, LocalsHashmap &);
     SharedPtr<Node> parse_call_expression_without_parens(SharedPtr<Node>, LocalsHashmap &);

--- a/src/node/begin_rescue_node.cpp
+++ b/src/node/begin_rescue_node.cpp
@@ -1,14 +1,15 @@
 #include "natalie_parser/node/begin_rescue_node.hpp"
 #include "natalie_parser/node/array_node.hpp"
 #include "natalie_parser/node/assignment_node.hpp"
+#include "natalie_parser/node/identifier_node.hpp"
 
 namespace NatalieParser {
 
-SharedPtr<Node> BeginRescueNode::name_to_node() const {
+SharedPtr<Node> BeginRescueNode::name_to_assignment() const {
     assert(m_name);
     return new AssignmentNode {
         token(),
-        m_name.static_cast_as<Node>(),
+        m_name,
         new IdentifierNode {
             Token { Token::Type::GlobalVariable, "$!", file(), line(), column(), false },
             false },
@@ -21,7 +22,7 @@ void BeginRescueNode::transform(Creator *creator) const {
     for (auto exception_node : m_exceptions)
         array.add_node(exception_node);
     if (m_name)
-        array.add_node(name_to_node());
+        array.add_node(name_to_assignment());
     creator->append(array);
     if (m_body->nodes().is_empty())
         creator->append_nil();


### PR DESCRIPTION
```rb
begin; rescue => @@captured_error; end
begin; rescue => CapturedError; end
begin; rescue => $captured_error; end
begin; rescue => @captured_error; end
begin; rescue => self&.captured_error; end
begin; rescue => self.captured_error; end
begin; rescue => self[:error]; end
```

Also see https://iliabylich.github.io/2018/07/18/my-favorite-parts-of-ruby.html#dynamicity-of-rescue