### PR TITLE
Revert "Add lexer support for leading-zero (bare) octal - e.g. 0777"

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1288,26 +1288,7 @@ Token Lexer::consume_numeric() {
             break;
         }
         default:
-            char c = peek();
-
-            if (isdigit(c)) {
-                // bare octal case, e.g. 0777.
-                // If starts with a 0 but next number is not 0..7 then that's an error.
-                if (!(c >= '0' && c <= '7'))
-                    return Token { Token::Type::Invalid, c, m_file, m_cursor_line,
-                        m_cursor_column, m_whitespace_precedes };
-                chars->append_char(c);
-                c = next();
-                do {
-                    chars->append_char(c);
-                    c = next();
-                    if (c == '_')
-                        c = next();
-                } while (c >= '0' && c <= '7');
-                token = chars_to_fixnum_or_bignum_token(chars, 8, 1);
-            } else {
-                token = consume_decimal_digits_and_build_token();
-            }
+            token = consume_decimal_digits_and_build_token();
         }
     } else {
         token = consume_decimal_digits_and_build_token();

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # skip-ruby
 
 require_relative './test_helper'
@@ -268,7 +267,7 @@ describe 'NatalieParser' do
     end
 
     it 'tokenizes fixnums' do
-      expect(tokenize('1 123 +1 -456 - 0 100_000_000 0d5 0D6 0o10 0O11 0777 07654321 0xff 0XFF 0b110 0B111')).must_equal [
+      expect(tokenize('1 123 +1 -456 - 0 100_000_000 0d5 0D6 0o10 0O11 0xff 0XFF 0b110 0B111')).must_equal [
         { type: :fixnum, literal: 1 },
         { type: :fixnum, literal: 123 },
         { type: :'+' },
@@ -282,8 +281,6 @@ describe 'NatalieParser' do
         { type: :fixnum, literal: 6 }, # 0D6
         { type: :fixnum, literal: 8 }, # 0o10
         { type: :fixnum, literal: 9 }, # 0O11
-        { type: :fixnum, literal: 511 }, # 0777
-        { type: :fixnum, literal: 2054353}, #07654321
         { type: :fixnum, literal: 255 }, # 0xff
         { type: :fixnum, literal: 255 }, # 0XFF
         { type: :fixnum, literal: 6 }, # 0b110


### PR DESCRIPTION
Reverts natalie-lang/natalie_parser#40

I merged 40 without looking at the build status. My bad!