### PR TITLE
Reduce usage of SharedPtr in methods and functions

### DIFF
--- a/ext/natalie_parser/mri_creator.hpp
+++ b/ext/natalie_parser/mri_creator.hpp
@@ -25,7 +25,7 @@ public:
 
     virtual void reset_sexp() override {
         m_sexp = rb_class_new_instance(0, nullptr, Sexp);
-        rb_ivar_set(m_sexp, rb_intern("@file"), get_file_string(file()));
+        rb_ivar_set(m_sexp, rb_intern("@file"), get_file_string(*file()));
         rb_ivar_set(m_sexp, rb_intern("@line"), rb_int_new(line() + 1));
         rb_ivar_set(m_sexp, rb_intern("@column"), rb_int_new(column() + 1));
     }
@@ -139,13 +139,13 @@ public:
 private:
     VALUE m_sexp { Qnil };
 
-    static VALUE get_file_string(SharedPtr<const String> file) {
-        auto file_string = s_file_cache.get(*file);
+    static VALUE get_file_string(const String &file) {
+        auto file_string = s_file_cache.get(file);
         if (!file_string) {
-            file_string = rb_str_new(file->c_str(), file->length());
+            file_string = rb_str_new(file.c_str(), file.length());
             // FIXME: Seems there is no way to un-register and object. :-(
             rb_gc_register_mark_object(file_string);
-            s_file_cache.put(*file, file_string);
+            s_file_cache.put(file, file_string);
         }
         return file_string;
     }

--- a/ext/natalie_parser/natalie_parser.cpp
+++ b/ext/natalie_parser/natalie_parser.cpp
@@ -27,9 +27,9 @@ VALUE initialize(int argc, VALUE *argv, VALUE self) {
     return self;
 }
 
-VALUE node_to_ruby(TM::SharedPtr<NatalieParser::Node> node) {
-    NatalieParser::MRICreator creator { node.ref() };
-    node->transform(&creator);
+VALUE node_to_ruby(const NatalieParser::Node &node) {
+    NatalieParser::MRICreator creator { node };
+    node.transform(&creator);
     return creator.sexp();
 }
 
@@ -41,7 +41,7 @@ VALUE parse_on_instance(VALUE self) {
     auto parser = NatalieParser::Parser { code_string, path_string };
     try {
         auto tree = parser.tree();
-        VALUE ast = node_to_ruby(tree);
+        VALUE ast = node_to_ruby(*tree);
         return ast;
     } catch (NatalieParser::Parser::SyntaxError &error) {
         rb_raise(rb_eSyntaxError, "%s", error.message());


### PR DESCRIPTION
This change is according to [rule F.7 of the C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f7-for-general-use-take-t-or-t-arguments-rather-than-smart-pointers).

This change is far from complete, but a lot of changed might require access to the raw pointer to use casts to subtypes, but SharedPtr does not expose an interface to access that.