### PR TITLE
Make SyntaxError::message a const member function

### DIFF
--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -28,7 +28,7 @@ public:
         SyntaxError(const SyntaxError &) = delete;
         SyntaxError &operator=(const SyntaxError &) = delete;
 
-        const char *message() { return m_message; }
+        const char *message() const { return m_message; }
 
     private:
         char *m_message { nullptr };


### PR DESCRIPTION
This way the exceptions can be caught as constant references if you need the message method. This makes its usages more in line with the C++ Core Guidelines (E.15: Throw by value, catch exceptions from a hierarchy by reference)