### PR TITLE
Fix method call with top-level constant as first arg

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2953,6 +2953,8 @@ Parser::parse_left_fn Parser::left_denotation(Token &token, SharedPtr<Node> left
             return &Parser::parse_call_expression_with_parens;
         break;
     case Type::ConstantResolution:
+        if (token.whitespace_precedes())
+            return &Parser::parse_call_expression_without_parens;
         return &Parser::parse_constant_resolution_expression;
     case Type::Ampersand:
     case Type::Caret:

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -995,6 +995,8 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("p Foo::Bar:bar")).must_equal s(:call, nil, :p, s(:call, s(:const, :Foo), :Bar, s(:lit, :bar)))
         expect(-> { parse("::Bar :bar") }).must_raise SyntaxError # not with colon3
         expect(parse('foo $&')).must_equal s(:call, nil, :foo, s(:back_ref, :&))
+        expect(parse('foo ::Bar')).must_equal s(:call, nil, :foo, s(:colon3, :Bar))
+        expect(parse('Foo ::Bar')).must_equal s(:call, nil, :Foo, s(:colon3, :Bar))
       end
 
       it 'parses safe calls' do


### PR DESCRIPTION
Fix this:

```ruby
include ::Kernel
```