### PR TITLE
Implement :valias for global variable aliasing

### DIFF
--- a/include/natalie_parser/node.hpp
+++ b/include/natalie_parser/node.hpp
@@ -89,6 +89,7 @@
 #include "natalie_parser/node/unary_op_node.hpp"
 #include "natalie_parser/node/undef_node.hpp"
 #include "natalie_parser/node/until_node.hpp"
+#include "natalie_parser/node/valias_node.hpp"
 #include "natalie_parser/node/while_node.hpp"
 #include "natalie_parser/node/yield_node.hpp"
 #include "natalie_parser/token.hpp"

--- a/include/natalie_parser/node/node.hpp
+++ b/include/natalie_parser/node/node.hpp
@@ -99,6 +99,7 @@ public:
         UnaryOp,
         Undef,
         Until,
+        Valias,
         While,
         Yield,
     };

--- a/include/natalie_parser/node/valias_node.hpp
+++ b/include/natalie_parser/node/valias_node.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "natalie_parser/node/node.hpp"
+#include "natalie_parser/node/node_with_args.hpp"
+#include "tm/hashmap.hpp"
+#include "tm/string.hpp"
+
+namespace NatalieParser {
+
+using namespace TM;
+
+class ValiasNode : public Node {
+public:
+    ValiasNode(const Token &token, SharedPtr<String> new_name, SharedPtr<String> existing_name)
+        : Node { token }
+        , m_new_name { new_name }
+        , m_existing_name { existing_name } {
+        assert(m_new_name);
+        assert(m_existing_name);
+    }
+
+    virtual Type type() const override { return Type::Valias; }
+
+    SharedPtr<String> new_name() const { return m_new_name; }
+    SharedPtr<String> existing_name() const { return m_existing_name; }
+
+    virtual void transform(Creator *creator) const override {
+        creator->set_type("valias");
+        creator->append_symbol(m_new_name);
+        creator->append_symbol(m_existing_name);
+    }
+
+protected:
+    SharedPtr<String> m_new_name {};
+    SharedPtr<String> m_existing_name {};
+};
+}

--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -75,6 +75,8 @@ private:
     void reinsert_collapsed_newline();
     SharedPtr<Node> parse_alias(LocalsHashmap &);
     SharedPtr<SymbolNode> parse_alias_arg(LocalsHashmap &, const char *);
+    SharedPtr<String> parse_valias_arg(bool allow_number, const char *);
+
     SharedPtr<Node> parse_array(LocalsHashmap &);
     SharedPtr<Node> parse_back_ref(LocalsHashmap &);
     SharedPtr<Node> parse_begin_block(LocalsHashmap &);

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require_relative './test_helper'
 require_relative './support/expectations'
 require_relative '../lib/natalie_parser/sexp'
@@ -1720,6 +1721,17 @@ require_relative '../lib/natalie_parser/sexp'
         expect(parse("alias foo= and=\ndef foo; end")).must_equal s(:block, s(:alias, s(:lit, :foo=), s(:lit, :and=)), s(:defn, :foo, s(:args), s(:nil)))
       end
 
+      it "parses valias" do
+        expect(parse('alias $ZZ $ZAP')).must_equal s(:valias, :"$ZZ", :"$ZAP")
+        expect(parse('alias $zz $z')).must_equal s(:valias, :"$zz", :"$z")
+        expect(parse('alias $1 $ABC')).must_equal s(:valias, :"$1", :"$ABC") # $number in 1st pos
+        expect(parse('alias $& $&')).must_equal s(:valias, :"$&", :"$&") # backrefs 
+
+        expect_raise_with_message(-> { parse('alias $A A') }, SyntaxError, /error/)
+        expect_raise_with_message(-> { parse('alias $A 1') }, SyntaxError, /error/)
+        expect_raise_with_message(-> { parse('alias $A $1') }, SyntaxError, /can't make alias for the number variables/)
+                
+      end
       it 'parses defined?' do
         expect(parse('defined? foo')).must_equal s(:defined, s(:call, nil, :foo))
         expect(parse('defined?(:foo)')).must_equal s(:defined, s(:lit, :foo))

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # (The MIT License)
 # 
 # Copyright © Ryan Davis, seattle.rb
@@ -139,7 +140,6 @@ module TestRubyParserShared
   end
 
   def test_alias_gvar_backref
-    skip
     rb = "alias $MATCH $&"
     pt = s(:valias, :$MATCH, :$&)
 


### PR DESCRIPTION
Based on trial and error to see what s-expressions are generated with RubyParser, I implemented the `:valias` s-expression which is used for global variable aliases.  

This allowed removing a `skip` from one of the test_ruby_parser.rb tests which was helpful because until looking at that spec and associated internals I didnt realize GlobalVariable, BackRef and NthRef were separate entities.

Fixes #49 
